### PR TITLE
fix: actually set vcom gpio value

### DIFF
--- a/src/drm_iface.c
+++ b/src/drm_iface.c
@@ -77,7 +77,7 @@ static void vcom_timer_callback(struct timer_list *t)
 
 	// Toggle the GPIO pin
 	vcom_setting = (vcom_setting) ? 0 : 1;
-	gpiod_set_value(panel->gpio_vcom, 1);
+	gpiod_set_value(panel->gpio_vcom, vcom_setting);
 
 	// Reschedule the timer
 	mod_timer(&panel->vcom_timer, jiffies + msecs_to_jiffies(1000));


### PR DESCRIPTION
this was hard coded to always set the vcom to 1 when instead it's supposed to be alternating on and off