### PR TITLE
fix compiler warnings: prototypes for main funcs, comment unused vars

### DIFF
--- a/src/drm_iface.c
+++ b/src/drm_iface.c
@@ -60,8 +60,9 @@
 
 // Globals
 
-static void __iomem *g_spi_cs_reg1 = NULL;
-static void __iomem *g_spi_cs_reg2 = NULL;
+//unused
+// static void __iomem *g_spi_cs_reg1 = NULL;
+// static void __iomem *g_spi_cs_reg2 = NULL;
 
 struct overlay_storage_t
 {

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include <linux/platform_device.h>
 #include <linux/spi/spi.h>
 
+#include "sharp_memory.h"
 #include "drm_iface.h"
 #include "params_iface.h"
 #include "ioctl_iface.h"

--- a/src/sharp_memory.h
+++ b/src/sharp_memory.h
@@ -1,0 +1,11 @@
+#ifndef SHARP_MEMORY_H_
+#define SHARP_MEMORY_H_
+
+void sharp_memory_set_invert(int setting);
+void* sharp_memory_add_overlay(int x, int y, int width, int height, unsigned char const* pixels);
+void sharp_memory_remove_overlay(void* entry);
+void* sharp_memory_show_overlay(void* storage);
+void sharp_memory_hide_overlay(void* display);
+void sharp_memory_clear_overlays(void);
+
+#endif


### PR DESCRIPTION
when building on alpine/pmos, the compiler has warnings about unused variables and missing prototypes. 